### PR TITLE
Feature/sn 633 fix failing tests

### DIFF
--- a/src/Saritasa.NetForge.Tests/EfCoreDataServiceTests/CreateEntityTests.cs
+++ b/src/Saritasa.NetForge.Tests/EfCoreDataServiceTests/CreateEntityTests.cs
@@ -1,11 +1,7 @@
 ﻿using Saritasa.NetForge.Infrastructure.Abstractions.Interfaces;
 using Saritasa.NetForge.Tests.Domain;
-using Saritasa.NetForge.Tests.Fixtures;
 using Saritasa.NetForge.Tests.Helpers;
 using Xunit;
-using Xunit.Abstractions;
-using Xunit.Microsoft.DependencyInjection.Abstracts;
-using Xunit.Microsoft.DependencyInjection.Attributes;
 using ContactInfo = Saritasa.NetForge.Tests.Domain.Models.ContactInfo;
 
 namespace Saritasa.NetForge.Tests.EfCoreDataServiceTests;
@@ -13,29 +9,52 @@ namespace Saritasa.NetForge.Tests.EfCoreDataServiceTests;
 /// <summary>
 /// Create entity tests.
 /// </summary>
-[TestCaseOrderer(Constants.OrdererTypeName, Constants.OrdererAssemblyName)]
-public class CreateEntityTests : TestBed<NetForgeFixture>
+public class CreateEntityTests : IDisposable
 {
-#pragma warning disable CA2213
     private readonly TestDbContext testDbContext;
-#pragma warning restore CA2213
     private readonly IOrmDataService efCoreDataService;
 
     /// <summary>
     /// Constructor.
     /// </summary>
-    public CreateEntityTests(ITestOutputHelper testOutputHelper, NetForgeFixture netForgeFixture)
-        : base(testOutputHelper, netForgeFixture)
+    public CreateEntityTests()
     {
-        testDbContext = _fixture.GetService<TestDbContext>(_testOutputHelper)!;
-        efCoreDataService = _fixture.GetService<IOrmDataService>(_testOutputHelper)!;
+        testDbContext = EfCoreHelper.CreateTestDbContext();
+        efCoreDataService = EfCoreHelper.CreateEfCoreDataService(testDbContext);
+    }
+
+    private bool disposedValue;
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Deletes the database after one test is complete,
+    /// so it gives us the same state of the database for every test.
+    /// </summary>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposedValue)
+        {
+            return;
+        }
+
+        if (disposing)
+        {
+            testDbContext.Dispose();
+        }
+
+        disposedValue = true;
     }
 
     /// <summary>
     /// Create valid entity test.
     /// </summary>
     [Fact]
-    [TestOrder(1)]
     public async Task CreateEntity_ValidEntity_Success()
     {
         // Arrange
@@ -53,7 +72,6 @@ public class CreateEntityTests : TestBed<NetForgeFixture>
     /// Create already existed entity test.
     /// </summary>
     [Fact]
-    [TestOrder(2)]
     public async Task CreateEntity_AlreadyExistingEntity_Error()
     {
         // Arrange

--- a/src/Saritasa.NetForge.Tests/EfCoreDataServiceTests/SearchTests.cs
+++ b/src/Saritasa.NetForge.Tests/EfCoreDataServiceTests/SearchTests.cs
@@ -17,7 +17,9 @@ namespace Saritasa.NetForge.Tests.EfCoreDataServiceTests;
 [CollectionDefinition(Constants.DependencyInjection)]
 public class SearchTests : TestBed<NetForgeFixture>
 {
+#pragma warning disable CA2213
     private readonly TestDbContext testDbContext;
+#pragma warning restore CA2213
     private readonly IOrmDataService dataService;
 
     /// <summary>

--- a/src/Saritasa.NetForge.Tests/EfCoreDataServiceTests/SearchTests.cs
+++ b/src/Saritasa.NetForge.Tests/EfCoreDataServiceTests/SearchTests.cs
@@ -26,7 +26,7 @@ public class SearchTests : TestBed<NetForgeFixture>
     public SearchTests(ITestOutputHelper testOutputHelper, NetForgeFixture netForgeFixture)
         : base(testOutputHelper, netForgeFixture)
     {
-        testDbContext = netForgeFixture.TestDbContext;
+        testDbContext = netForgeFixture.GetService<TestDbContext>(testOutputHelper)!;
         dataService = netForgeFixture.GetScopedService<IOrmDataService>(testOutputHelper)!;
 
         PopulateDatabaseWithTestData();

--- a/src/Saritasa.NetForge.Tests/EfCoreDataServiceTests/UpdateEntityTests.cs
+++ b/src/Saritasa.NetForge.Tests/EfCoreDataServiceTests/UpdateEntityTests.cs
@@ -2,38 +2,60 @@
 using Saritasa.NetForge.DomainServices.Extensions;
 using Saritasa.NetForge.Infrastructure.Abstractions.Interfaces;
 using Saritasa.NetForge.Tests.Domain;
-using Saritasa.NetForge.Tests.Fixtures;
 using Saritasa.NetForge.Tests.Helpers;
 using Xunit;
-using Xunit.Abstractions;
-using Xunit.Microsoft.DependencyInjection.Abstracts;
 
 namespace Saritasa.NetForge.Tests.EfCoreDataServiceTests;
 
 /// <summary>
 /// Tests for <see cref="IOrmDataService.UpdateAsync"/>.
 /// </summary>
-public class UpdateEntityTests : TestBed<NetForgeFixture>
+public class UpdateEntityTests : IDisposable
 {
-#pragma warning disable CA2213
     private readonly TestDbContext testDbContext;
-#pragma warning restore CA2213
     private readonly IOrmDataService efCoreDataService;
 
     /// <summary>
     /// Constructor.
     /// </summary>
-    public UpdateEntityTests(ITestOutputHelper testOutputHelper, NetForgeFixture netForgeFixture)
-        : base(testOutputHelper, netForgeFixture)
+    public UpdateEntityTests()
     {
-        testDbContext = _fixture.GetService<TestDbContext>(_testOutputHelper)!;
-        efCoreDataService = _fixture.GetService<IOrmDataService>(_testOutputHelper)!;
+        testDbContext = EfCoreHelper.CreateTestDbContext();
+        efCoreDataService = EfCoreHelper.CreateEfCoreDataService(testDbContext);
 
         var shops = Fakers.ShopFaker.Generate(2);
         testDbContext.Shops.AddRange(shops);
         testDbContext.SaveChanges();
 
         testDbContext.ChangeTracker.Clear();
+    }
+
+    private bool disposedValue;
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Deletes the database after one test is complete,
+    /// so it gives us the same state of the database for every test.
+    /// </summary>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposedValue)
+        {
+            return;
+        }
+
+        if (disposing)
+        {
+            testDbContext.Dispose();
+        }
+
+        disposedValue = true;
     }
 
     /// <summary>

--- a/src/Saritasa.NetForge.Tests/Fixtures/NetForgeFixture.cs
+++ b/src/Saritasa.NetForge.Tests/Fixtures/NetForgeFixture.cs
@@ -14,27 +14,10 @@ namespace Saritasa.NetForge.Tests.Fixtures;
 /// </summary>
 public class NetForgeFixture : TestBedFixture
 {
-    internal TestDbContext TestDbContext { get; }
-
-    /// <summary>
-    /// Constructor. This code executes before tests.
-    /// </summary>
-    public NetForgeFixture()
-    {
-        var dbOptions = new DbContextOptionsBuilder<TestDbContext>()
-            .UseInMemoryDatabase("NetForgeTest")
-            .Options;
-
-        var testDbContext = new TestDbContext(dbOptions);
-        testDbContext.Database.EnsureCreated();
-
-        TestDbContext = testDbContext;
-    }
-
     /// <inheritdoc />
     protected override ValueTask DisposeAsyncCore()
     {
-        return TestDbContext.DisposeAsync();
+        return ValueTask.CompletedTask;
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
In this PR problem with tests isolation was fixed. The issue was: `UpdateEntityTests` changed database data and other tests access already changed database, that's why some tests were failed. Fixture was removed from `CreateEntityTests` and `UpdateEntityTests`.

For future tests: if your tests are changing some data, then do not use `NetForgeFixture`.