### PR TITLE
Exclude all Properties SN-748

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,2 +1,5 @@
 0.1.0-alpha [2024-08-16]
 [+] Initial release.
+
+0.2.0-alpha [2024-10-07]
+[+] Exclude all properties from entity.

--- a/README.md
+++ b/README.md
@@ -506,6 +506,20 @@ public string Property { get; set; }
 
 You can read about navigation properties [here](docs/NAVIGATIONS.md).
 
+## Exclude All Properties and Include Specific Only
+
+You can exclude all properties and include only specific ones. It works with both ordinary and navigation properties.
+
+**Using Fluent API**
+
+```csharp
+optionsBuilder.ConfigureEntity<User>(entityOptionsBuilder =>
+{
+    entityOptionsBuilder.ExcludeAllProperties();
+    entityOptionsBuilder.IncludeProperties(user => user.Id, user => user.Name);
+});
+```
+
 ## Exclude Property from Query
 
 You can explicitly control whether a property should be excluded from the data query.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The **NetForge** is a library that provides a user-friendly and intuitive user i
   - [Display Properties as Title Case](#display-properties-as-title-case)
   - [Default Values](#default-values)
   - [Navigation Properties](#navigation-properties)
+  - [Exclude All Properties and Include Specific Only](#exclude-all-properties-and-include-specific-only)
   - [Exclude Property from Query](#exclude-property-from-query)
   - [Formatting Property as HTML](#formatting-property-as-html)
   - [Generated Properties](#generated-properties)

--- a/src/Saritasa.NetForge.Blazor/Pages/EntityDetails.razor
+++ b/src/Saritasa.NetForge.Blazor/Pages/EntityDetails.razor
@@ -50,22 +50,32 @@
             </MudItem>
         }
 
-        <MudItem xs="12">
-            <MudDataGrid T="object" ServerData="ViewModel.LoadEntityGridDataAsync" DragDropColumnReordering="true"
-                         MultiSelection="true" @bind-SelectedItems="ViewModel.SelectedEntities"
-                         @ref="ViewModel.DataGrid" SortMode="SortMode.Multiple"
-                         @attributes="NonKeylessEntityDataGridAttributes">
-                <Columns>
-                    <EntityPropertyColumns Properties="ViewModel.Model.Properties"
-                                           DataGrid="ViewModel.DataGrid"
-                                           CanDelete="ViewModel.CanDelete"/>
-                </Columns>
+        @if (!ViewModel.HasProperties)
+        {
+            <MudItem xs="12">
+                <MudText Typo="Typo.body1">This entity doesn't have configured properties to display.</MudText>
+            </MudItem>
+        }
 
-                <PagerContent>
-                    <MudDataGridPager T="object"/>
-                </PagerContent>
-            </MudDataGrid>
-        </MudItem>
+        @if (ViewModel.HasProperties)
+        {
+            <MudItem xs="12">
+                <MudDataGrid T="object" ServerData="ViewModel.LoadEntityGridDataAsync" DragDropColumnReordering="true"
+                             MultiSelection="true" @bind-SelectedItems="ViewModel.SelectedEntities"
+                             @ref="ViewModel.DataGrid" SortMode="SortMode.Multiple"
+                             @attributes="NonKeylessEntityDataGridAttributes">
+                    <Columns>
+                        <EntityPropertyColumns Properties="ViewModel.Model.Properties"
+                                               DataGrid="ViewModel.DataGrid"
+                                               CanDelete="ViewModel.CanDelete"/>
+                    </Columns>
+
+                    <PagerContent>
+                        <MudDataGridPager T="object"/>
+                    </PagerContent>
+                </MudDataGrid>
+            </MudItem>
+        }
     </MudGrid>
 }
 else

--- a/src/Saritasa.NetForge.Domain/Entities/Options/EntityOptions.cs
+++ b/src/Saritasa.NetForge.Domain/Entities/Options/EntityOptions.cs
@@ -84,4 +84,14 @@ public class EntityOptions
 
     /// <inheritdoc cref="EntityMetadata.CanDelete"/>
     public bool? CanDelete { get; set; }
+
+    /// <summary>
+    /// Whether to exclude all properties from displaying.
+    /// </summary>
+    public bool ExcludeAllProperties { get; set; }
+
+    /// <summary>
+    /// Properties to include.
+    /// </summary>
+    public List<string> IncludedProperties { get; set; } = new();
 }

--- a/src/Saritasa.NetForge.DomainServices/EntityOptionsBuilder.cs
+++ b/src/Saritasa.NetForge.DomainServices/EntityOptionsBuilder.cs
@@ -184,4 +184,28 @@ public class EntityOptionsBuilder<TEntity> where TEntity : class
         options.CanDelete = canDelete;
         return this;
     }
+
+    /// <summary>
+    /// Excludes all properties by default.
+    /// This method can be used in conjunction with <see cref="IncludeProperties"/> to include specific properties
+    /// after excluding all.
+    /// </summary>
+    public EntityOptionsBuilder<TEntity> ExcludeAllProperties()
+    {
+        options.ExcludeAllProperties = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Includes specific properties.
+    /// This method can be used in conjunction with <see cref="ExcludeAllProperties"/> to include specific
+    /// properties after excluding all.
+    /// </summary>
+    /// <param name="propertyExpressions">The expressions representing the properties to include.</param>
+    public EntityOptionsBuilder<TEntity> IncludeProperties(params Expression<Func<TEntity, object?>>[] propertyExpressions)
+    {
+        var propertyNames = propertyExpressions.Select(expression => expression.GetMemberName());
+        options.IncludedProperties.AddRange(propertyNames);
+        return this;
+    }
 }

--- a/src/Saritasa.NetForge.Mvvm/ViewModels/EntityDetails/EntityDetailsViewModel.cs
+++ b/src/Saritasa.NetForge.Mvvm/ViewModels/EntityDetails/EntityDetailsViewModel.cs
@@ -94,9 +94,9 @@ public class EntityDetailsViewModel : BaseViewModel
                                    })
                                    || Model.SearchFunction is not null;
 
-            CanAdd = Model is { CanAdd: true, IsKeyless: false } && Model.Properties.Any();
-            CanEdit = Model is { CanEdit: true, IsKeyless: false } && Model.Properties.Any();
-            CanDelete = Model is { CanDelete: true, IsKeyless: false } && Model.Properties.Any();
+            CanAdd = Model is { CanAdd: true, IsKeyless: false } && HasProperties;
+            CanEdit = Model is { CanEdit: true, IsKeyless: false } && HasProperties;
+            CanDelete = Model is { CanDelete: true, IsKeyless: false } && HasProperties;
         }
         catch (NotFoundException)
         {

--- a/src/Saritasa.NetForge.Mvvm/ViewModels/EntityDetails/EntityDetailsViewModel.cs
+++ b/src/Saritasa.NetForge.Mvvm/ViewModels/EntityDetails/EntityDetailsViewModel.cs
@@ -89,9 +89,9 @@ public class EntityDetailsViewModel : BaseViewModel
                                    })
                                    || Model.SearchFunction is not null;
 
-            CanAdd = Model is { CanAdd: true, IsKeyless: false };
-            CanEdit = Model is { CanEdit: true, IsKeyless: false };
-            CanDelete = Model is { CanDelete: true, IsKeyless: false };
+            CanAdd = Model is { CanAdd: true, IsKeyless: false } && Model.Properties.Any();
+            CanEdit = Model is { CanEdit: true, IsKeyless: false } && Model.Properties.Any();
+            CanDelete = Model is { CanDelete: true, IsKeyless: false } && Model.Properties.Any();
         }
         catch (NotFoundException)
         {

--- a/src/Saritasa.NetForge.Mvvm/ViewModels/EntityDetails/EntityDetailsViewModel.cs
+++ b/src/Saritasa.NetForge.Mvvm/ViewModels/EntityDetails/EntityDetailsViewModel.cs
@@ -65,6 +65,11 @@ public class EntityDetailsViewModel : BaseViewModel
     public bool CanDelete { get; set; }
 
     /// <summary>
+    /// Whether entity has properties included.
+    /// </summary>
+    public bool HasProperties => Model.Properties.Any();
+
+    /// <summary>
     /// Selected entities.
     /// </summary>
     public HashSet<object> SelectedEntities { get; set; } = new();

--- a/src/Saritasa.NetForge.UseCases/Metadata/Services/AdminMetadataService.cs
+++ b/src/Saritasa.NetForge.UseCases/Metadata/Services/AdminMetadataService.cs
@@ -77,9 +77,11 @@ public class AdminMetadataService
         {
             case true when entityOptions.IncludedProperties.Any():
                 entityMetadata.Properties.RemoveAll(p => !entityOptions.IncludedProperties.Contains(p.Name));
+                entityMetadata.Navigations.RemoveAll(p => !entityOptions.IncludedProperties.Contains(p.Name));
                 break;
             case true:
                 entityMetadata.Properties.Clear();
+                entityMetadata.Navigations.Clear();
                 break;
         }
     }

--- a/src/Saritasa.NetForge.UseCases/Metadata/Services/AdminMetadataService.cs
+++ b/src/Saritasa.NetForge.UseCases/Metadata/Services/AdminMetadataService.cs
@@ -55,6 +55,12 @@ public class AdminMetadataService
                 var calculatedProperties = GetCalculatedPropertiesMetadata(entityOptions);
                 entityMetadata.Properties.AddRange(calculatedProperties);
                 entityMetadata.ApplyOptions(entityOptions, adminOptions);
+
+                if (entityOptions.ExcludeAllProperties)
+                {
+                    // Exclude properties if it was specified in the entity options.
+                    ExcludeProperties(entityMetadata, entityOptions);
+                }
             }
 
             entityMetadata.ApplyEntityAttributes(adminOptions);
@@ -63,6 +69,19 @@ public class AdminMetadataService
 
         CacheMetadata(metadata);
         return metadata;
+    }
+
+    private static void ExcludeProperties(EntityMetadata entityMetadata, EntityOptions entityOptions)
+    {
+        switch (entityOptions.ExcludeAllProperties)
+        {
+            case true when entityOptions.IncludedProperties.Any():
+                entityMetadata.Properties.RemoveAll(p => !entityOptions.IncludedProperties.Contains(p.Name));
+                break;
+            case true:
+                entityMetadata.Properties.Clear();
+                break;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
https://saritasa.atlassian.net/browse/SN-748

Now we can exclude all properties from the entity and include only specific ones. The configuration is applicable for both ordinary and navigation properties.

The properties will be excluded from the list view and details page.