### PR TITLE
SN-736   NetForge - Details of Navigation Reference

### DIFF
--- a/demo/Saritasa.NetForge.Demo/Infrastructure/Admin/ShopAdminConfiguration.cs
+++ b/demo/Saritasa.NetForge.Demo/Infrastructure/Admin/ShopAdminConfiguration.cs
@@ -1,5 +1,4 @@
-﻿using Saritasa.NetForge.Demo.Infrastructure.UploadFiles;
-using Saritasa.NetForge.Demo.Infrastructure.UploadFiles.Strategies;
+﻿using Saritasa.NetForge.Demo.Infrastructure.UploadFiles.Strategies;
 using Saritasa.NetForge.Demo.Models;
 using Saritasa.NetForge.Domain.Enums;
 using Saritasa.NetForge.DomainServices;
@@ -65,7 +64,8 @@ public class ShopAdminConfiguration : IEntityAdminConfiguration<Shop>
                             .SetIsSortable(true)
                             .SetSearchType(SearchType.ContainsCaseInsensitive);
                     })
-                    .SetDisplayDetails(true);
+                    .SetDisplayDetails(true)
+                    .SetAsEditable();
             })
             .IncludeNavigation<Product>(shop => shop.Products, navigationOptionsBuilder =>
             {

--- a/docs/NAVIGATIONS.md
+++ b/docs/NAVIGATIONS.md
@@ -107,7 +107,7 @@ public void Configure(EntityOptionsBuilder<Shop> entityOptionsBuilder)
                     builder.SetDisplayName("Address Id");
                 })
                 .SetIsDisplayDetails(true)
-				.SetAsEditable();
+                .SetAsEditable();
         })
 }
 ```

--- a/docs/NAVIGATIONS.md
+++ b/docs/NAVIGATIONS.md
@@ -85,3 +85,29 @@ public void Configure(EntityOptionsBuilder<Shop> entityOptionsBuilder)
 ### Collection
 
 Collection navigations have this behavior by default.
+
+## Edit navigation data
+
+You can edit navigation data directly from parent entity list view page by click on the navigation link.
+
+### Reference
+
+For reference edit of navigation data you need to configure it via `Fluent API`. Note that only primary key of the entity is clickable to edit navigation data.
+Note that if both navigation methods are called, the .SetAsEditable() method has higher priority than .SetIsDisplayDetails(true).
+
+```csharp
+public void Configure(EntityOptionsBuilder<Shop> entityOptionsBuilder)
+{
+    entityOptionsBuilder
+        .IncludeNavigation<Address>(shop => shop.Address, navigationOptionsBuilder =>
+        {
+            navigationOptionsBuilder
+                .IncludeProperty(address => address.Id, builder =>
+                {
+                    builder.SetDisplayName("Address Id");
+                })
+                .SetIsDisplayDetails(true)
+				.SetAsEditable();
+        })
+}
+```

--- a/src/Saritasa.NetForge.Blazor/Controls/EntityPropertyColumns.razor
+++ b/src/Saritasa.NetForge.Blazor/Controls/EntityPropertyColumns.razor
@@ -119,6 +119,15 @@
                     {
                         @((MarkupString)propertyValue!)
                     }
+                    else if (navigation is not null && navigation.EditDetails
+                            && property.IsPrimaryKey)
+                    {
+                        <MudButton Variant="Variant.Text" Color="Color.Primary"
+                                   OnClick="() => NavigateToEditing(navigationMetadata: navigation,
+                                       navigationIdentifier: propertyValue)">
+                            @propertyValue
+                        </MudButton>
+                    }
                     else if (navigation is not null
                              && (navigation.DisplayDetails && property.IsPrimaryKey
                                  || navigation.IsCollection))

--- a/src/Saritasa.NetForge.Blazor/Controls/EntityPropertyColumns.razor.cs
+++ b/src/Saritasa.NetForge.Blazor/Controls/EntityPropertyColumns.razor.cs
@@ -197,7 +197,7 @@ public partial class EntityPropertyColumns : ComponentBase
         var entityMetadata = await EntityService.GetEntityByTypeAsync(navigationMetadata.ClrType!, CancellationToken.None);
 
         NavigationService.NavigateTo<Mvvm.ViewModels.EditEntity.EditEntityViewModel>(
-            parameters: new[] { entityMetadata.PluralName, navigationIdentifier });
+            parameters: [entityMetadata.PluralName, navigationIdentifier]);
     }
 
     /// <summary>

--- a/src/Saritasa.NetForge.Blazor/Controls/EntityPropertyColumns.razor.cs
+++ b/src/Saritasa.NetForge.Blazor/Controls/EntityPropertyColumns.razor.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Components;
 using MudBlazor;
 using Saritasa.NetForge.Domain.Entities.Options;
 using Saritasa.NetForge.DomainServices.Extensions;
+using Saritasa.NetForge.Mvvm.Navigation;
 using Saritasa.NetForge.Mvvm.Utils;
 using Saritasa.NetForge.UseCases.Constants;
 using Saritasa.NetForge.UseCases.Interfaces;
@@ -29,6 +30,9 @@ public partial class EntityPropertyColumns : ComponentBase
 
     [Inject]
     private IEntityService EntityService { get; set; } = null!;
+
+    [Inject]
+    private INavigationService NavigationService { get; set; } = null!;
 
     /// <summary>
     /// Properties of the entity.
@@ -183,6 +187,17 @@ public partial class EntityPropertyColumns : ComponentBase
             { nameof(navigationMetadata), navigationMetadata }
         };
         await DialogService.ShowAsync<NavigationDialog>(title: string.Empty, parameters, options);
+    }
+
+    /// <summary>
+    /// Edit navigation entity by its identifier.
+    /// </summary>
+    private async Task NavigateToEditing(NavigationMetadataDto navigationMetadata, object navigationIdentifier)
+    {
+        var entityMetadata = await EntityService.GetEntityByTypeAsync(navigationMetadata.ClrType!, CancellationToken.None);
+
+        NavigationService.NavigateTo<Mvvm.ViewModels.EditEntity.EditEntityViewModel>(
+            parameters: new[] { entityMetadata.PluralName, navigationIdentifier });
     }
 
     /// <summary>

--- a/src/Saritasa.NetForge.Domain/Entities/Metadata/NavigationMetadata.cs
+++ b/src/Saritasa.NetForge.Domain/Entities/Metadata/NavigationMetadata.cs
@@ -24,4 +24,9 @@ public class NavigationMetadata : PropertyMetadataBase
     /// Whether display details of navigation's data.
     /// </summary>
     public bool DisplayDetails { get; set; }
+
+    /// <summary>
+    /// Whether edit details of navigation's data.
+    /// </summary>
+    public bool EditDetails { get; set; }
 }

--- a/src/Saritasa.NetForge.Domain/Entities/Options/NavigationOptions.cs
+++ b/src/Saritasa.NetForge.Domain/Entities/Options/NavigationOptions.cs
@@ -20,4 +20,7 @@ public class NavigationOptions
 
     /// <inheritdoc cref="NavigationMetadata.DisplayDetails"/>
     public bool DisplayDetails { get; set; }
+
+    /// <inheritdoc cref="NavigationMetadata.EditDetails"/>
+    public bool EditDetails { get; set; }
 }

--- a/src/Saritasa.NetForge.DomainServices/Extensions/EntityMetadataOptionsExtensions.cs
+++ b/src/Saritasa.NetForge.DomainServices/Extensions/EntityMetadataOptionsExtensions.cs
@@ -180,5 +180,6 @@ public static class EntityMetadataOptionsExtensions
         }
 
         navigation.DisplayDetails = navigationOptions.DisplayDetails;
+        navigation.EditDetails = navigationOptions.EditDetails;
     }
 }

--- a/src/Saritasa.NetForge.DomainServices/NavigationOptionsBuilder.cs
+++ b/src/Saritasa.NetForge.DomainServices/NavigationOptionsBuilder.cs
@@ -50,4 +50,13 @@ public class NavigationOptionsBuilder<TEntity>
         options.DisplayDetails = displayDetails;
         return this;
     }
+
+    /// <summary>
+    /// Sets whether edit navigation entity details.
+    /// </summary>
+    public NavigationOptionsBuilder<TEntity> SetAsEditable()
+    {
+        options.EditDetails = true;
+        return this;
+    }
 }

--- a/src/Saritasa.NetForge.UseCases/Metadata/GetEntityById/NavigationMetadataDto.cs
+++ b/src/Saritasa.NetForge.UseCases/Metadata/GetEntityById/NavigationMetadataDto.cs
@@ -15,4 +15,7 @@ public record NavigationMetadataDto : PropertyMetadataDto
 
     /// <inheritdoc cref="NavigationMetadata.DisplayDetails"/>
     public bool DisplayDetails { get; set; }
+
+    /// <inheritdoc cref="NavigationMetadata.EditDetails"/>
+    public bool EditDetails { get; set; }
 }

--- a/src/Saritasa.NetForge.UseCases/Services/EntityService.cs
+++ b/src/Saritasa.NetForge.UseCases/Services/EntityService.cs
@@ -172,7 +172,8 @@ public class EntityService : IEntityService
             IsMultiline = navigation.IsMultiline,
             Lines = navigation.Lines,
             MaxLines = navigation.MaxLines,
-            IsAutoGrow = navigation.IsAutoGrow
+            IsAutoGrow = navigation.IsAutoGrow,
+            DisplayDetails = navigation.DisplayDetails
         };
     }
 

--- a/src/Saritasa.NetForge.UseCases/Services/EntityService.cs
+++ b/src/Saritasa.NetForge.UseCases/Services/EntityService.cs
@@ -173,7 +173,8 @@ public class EntityService : IEntityService
             Lines = navigation.Lines,
             MaxLines = navigation.MaxLines,
             IsAutoGrow = navigation.IsAutoGrow,
-            DisplayDetails = navigation.DisplayDetails
+            DisplayDetails = navigation.DisplayDetails,
+            EditDetails = navigation.EditDetails
         };
     }
 


### PR DESCRIPTION
- Apply DisplayDetails flag value changes in EntityService.MapNavigation() method;
- Add EditDetails flag in the NavigationMetadata and apply this to navigation options and metadata DTO methods; add appropriate fluent API SetAsEditable() method;
- Add customization for navigation reference, to go to navigation reference edit page directly from parent entity list view page…n() method;
- Change the \docs\NAVIGATIONS.md