### PR TITLE
Display not found page when an entity is not found SN-839

### DIFF
--- a/src/Saritasa.NetForge/MVVM/ViewModels/EditEntity/EditEntityViewModel.cs
+++ b/src/Saritasa.NetForge/MVVM/ViewModels/EditEntity/EditEntityViewModel.cs
@@ -118,6 +118,10 @@ public class EditEntityViewModel : ValidationEntityViewModel
         {
             IsEntityExists = false;
         }
+        catch (InvalidOperationException) // This exception throw when GetInstanceAsync doesn't return a matching entity.
+        {
+            IsEntityExists = false;
+        }
     }
 
     private readonly IDictionary<PropertyMetadataDto, IBrowserFile> filesToUpload

--- a/src/Saritasa.NetForge/MVVM/ViewModels/EditEntity/EditEntityViewModel.cs
+++ b/src/Saritasa.NetForge/MVVM/ViewModels/EditEntity/EditEntityViewModel.cs
@@ -118,7 +118,8 @@ public class EditEntityViewModel : ValidationEntityViewModel
         {
             IsEntityExists = false;
         }
-        catch (InvalidOperationException) // This exception throw when GetInstanceAsync doesn't return a matching entity.
+        // This exception throw when GetInstanceAsync doesn't return a matching entity.
+        catch (InvalidOperationException)
         {
             IsEntityExists = false;
         }

--- a/src/Saritasa.NetForge/Pages/EditEntity.razor
+++ b/src/Saritasa.NetForge/Pages/EditEntity.razor
@@ -8,7 +8,7 @@
 
 @inherits MvvmComponentBase<EditEntityViewModel>
 
-@if (ViewModel.Model.EntityInstance is null)
+@if (ViewModel.Model.EntityInstance is null && (ViewModel.IsEntityExists))
 {
     <p>Loading...</p>
 }


### PR DESCRIPTION
Instead of creating a new page for entity not found, I reuse the `<NotFound />` component by tweaking the condition.
![image](https://github.com/user-attachments/assets/57ba13ae-ed6f-471c-ad35-b8de905c17d3)
