### PR TITLE
Feature/sn 833 fix lazy loading load speed

### DIFF
--- a/src/Saritasa.NetForge/Controls/CustomFields/NavigationCollectionField.razor.cs
+++ b/src/Saritasa.NetForge/Controls/CustomFields/NavigationCollectionField.razor.cs
@@ -41,13 +41,6 @@ public partial class NavigationCollectionField<T> : CustomField
             .Cast<T>()
             .OrderBy(instance => instance).ToList();
 
-        // In case of lazy loading - convert proxies to POCO instances.
-        if (NavigationInstances.Any() && NavigationInstances.First()!.GetType().IsLazyLoadingProxy())
-        {
-            NavigationInstances = NavigationInstances
-                .Select(instance => ProxyToPocoConverter.ConvertProxyToPoco(instance)).Cast<T>();
-        }
-
         EntityMetadata = await EntityService.GetEntityByTypeAsync(entityType, CancellationToken.None);
     }
 }

--- a/src/Saritasa.NetForge/Domain/Comparers/ObjectComparer.cs
+++ b/src/Saritasa.NetForge/Domain/Comparers/ObjectComparer.cs
@@ -1,4 +1,5 @@
 using Saritasa.NetForge.Domain.UseCases.Metadata.GetEntityById;
+using Saritasa.NetForge.Infrastructure.EfCore.Extensions;
 using Saritasa.NetForge.Infrastructure.Helpers;
 
 namespace Saritasa.NetForge.Domain.Comparers;
@@ -27,7 +28,20 @@ public class ObjectComparer<T> : IEqualityComparer<T>
             return true;
         }
 
-        if (x is null || y is null || x.GetType() != y.GetType())
+        if (x is null || y is null)
+        {
+            return false;
+        }
+
+        var xType = x.GetType();
+        var yType = y.GetType();
+
+        if (xType.IsLazyLoadingProxy() || yType.IsLazyLoadingProxy())
+        {
+            return xType.GetPocoType() == yType.GetPocoType();
+        }
+
+        if (xType != yType)
         {
             return false;
         }

--- a/src/Saritasa.NetForge/Infrastructure/EfCore/Extensions/EntityProxyExtensions.cs
+++ b/src/Saritasa.NetForge/Infrastructure/EfCore/Extensions/EntityProxyExtensions.cs
@@ -37,4 +37,16 @@ public static class EntityProxyExtensions
 
         return entityType.BaseType!;
     }
+
+    /// <summary>
+    /// Gets POCO type when the given type is lazy loading proxy.
+    /// </summary>
+    /// <param name="entityType">Entity type.</param>
+    /// <returns>
+    /// If given type is lazy loading proxy, returns POCO type, otherwise returns given type unchanged.
+    /// </returns>
+    public static Type GetPocoType(this Type entityType)
+    {
+        return !entityType.IsLazyLoadingProxy() ? entityType : entityType.BaseType!;
+    }
 }

--- a/src/Saritasa.NetForge/Infrastructure/EfCore/Extensions/EntityProxyExtensions.cs
+++ b/src/Saritasa.NetForge/Infrastructure/EfCore/Extensions/EntityProxyExtensions.cs
@@ -47,6 +47,6 @@ public static class EntityProxyExtensions
     /// </returns>
     public static Type GetPocoType(this Type entityType)
     {
-        return !entityType.IsLazyLoadingProxy() ? entityType : entityType.BaseType!;
+        return entityType.IsLazyLoadingProxy() ? entityType.BaseType! : entityType;
     }
 }

--- a/src/Saritasa.NetForge/Infrastructure/EfCore/Services/EfCoreDataService.cs
+++ b/src/Saritasa.NetForge/Infrastructure/EfCore/Services/EfCoreDataService.cs
@@ -302,19 +302,27 @@ public class EfCoreDataService : IOrmDataService
         NavigationEntry originalNavigationEntry,
         IEqualityComparer<object> comparer)
     {
-        // Case when the user want to remove navigation value
-        if (navigationEntry.CurrentValue is null && originalNavigationEntry.CurrentValue is not null)
+        var updatedNavigationReference = navigationEntry.CurrentValue;
+
+        // In case of lazy loading - convert proxies to POCO instances.
+        if (updatedNavigationReference is not null && updatedNavigationReference.GetType().IsLazyLoadingProxy())
         {
-            originalNavigationEntry.CurrentValue = navigationEntry.CurrentValue;
+            updatedNavigationReference = ProxyToPocoConverter.ConvertProxyToPoco(updatedNavigationReference);
+        }
+
+        // Case when the user want to remove navigation value
+        if (updatedNavigationReference is null && originalNavigationEntry.CurrentValue is not null)
+        {
+            originalNavigationEntry.CurrentValue = updatedNavigationReference;
         }
         else
         {
-            var isTracked = dbContext.IsTracked(navigationEntry.CurrentValue!, comparer);
+            var isTracked = dbContext.IsTracked(updatedNavigationReference!, comparer);
 
             if (!isTracked)
             {
-                dbContext.Attach(navigationEntry.CurrentValue!);
-                originalNavigationEntry.CurrentValue = navigationEntry.CurrentValue;
+                dbContext.Attach(updatedNavigationReference!);
+                originalNavigationEntry.CurrentValue = updatedNavigationReference;
             }
         }
     }
@@ -325,7 +333,17 @@ public class EfCoreDataService : IOrmDataService
         NavigationEntry navigationEntry,
         IEqualityComparer<object> comparer)
     {
-        var navigationCollectionInstance = (IEnumerable<object>)navigationEntry.CurrentValue!;
+        var navigationCollectionInstance = ((IEnumerable<object>)navigationEntry.CurrentValue!).ToList();
+
+        // In case of lazy loading - convert proxies to POCO instances.
+        for (var instanceIndex = 0; instanceIndex < navigationCollectionInstance.Count; instanceIndex++)
+        {
+            var instance = navigationCollectionInstance[instanceIndex];
+            if (instance.GetType().IsLazyLoadingProxy())
+            {
+                navigationCollectionInstance[instanceIndex] = ProxyToPocoConverter.ConvertProxyToPoco(instance)!;
+            }
+        }
 
         // Track added elements
         foreach (var element in navigationCollectionInstance)
@@ -338,7 +356,7 @@ public class EfCoreDataService : IOrmDataService
             }
         }
 
-        var originalNavigationCollectionInstance = (IEnumerable<object>)originalNavigationEntry.CurrentValue!;
+        var originalNavigationCollectionInstance = ((IEnumerable<object>)originalNavigationEntry.CurrentValue!).ToList();
 
         var addedElements = navigationCollectionInstance
             .Except(originalNavigationCollectionInstance, comparer);


### PR DESCRIPTION
Previously converting lazy loading proxy to POCO was in navigation collection control, it was causing very slow loading of edit page due to huge amount of requests to the database. I moved this converting to update method, so now we're converting only necessary navigation instances instead of all