### PR TITLE
Feature/sn 836 custom navigation collection display

### DIFF
--- a/demo/Saritasa.NetForge.Demo/Infrastructure/Admin/ShopAdminConfiguration.cs
+++ b/demo/Saritasa.NetForge.Demo/Infrastructure/Admin/ShopAdminConfiguration.cs
@@ -75,7 +75,7 @@ public class ShopAdminConfiguration : IEntityAdminConfiguration<Shop>
             })
             .IncludeNavigation<Product>(shop => shop.Products, navigationOptionsBuilder =>
             {
-                navigationOptionsBuilder.SetListViewPropertyNames([nameof(Product.Name)]);
+                navigationOptionsBuilder.SetListViewPropertyNames([nameof(Product.Id), nameof(Product.Name)]);
             })
             .IncludeNavigation<Supplier>(shop => shop.Suppliers, navigationOptionsBuilder =>
             {

--- a/demo/Saritasa.NetForge.Demo/Infrastructure/Admin/ShopAdminConfiguration.cs
+++ b/demo/Saritasa.NetForge.Demo/Infrastructure/Admin/ShopAdminConfiguration.cs
@@ -75,7 +75,7 @@ public class ShopAdminConfiguration : IEntityAdminConfiguration<Shop>
             })
             .IncludeNavigation<Product>(shop => shop.Products, navigationOptionsBuilder =>
             {
-                navigationOptionsBuilder.SetListViewPropertyNames([nameof(Product.Id), nameof(Product.Name)]);
+                navigationOptionsBuilder.SetListViewProperties([product => product.Id, product => product.Name]);
             })
             .IncludeNavigation<Supplier>(shop => shop.Suppliers, navigationOptionsBuilder =>
             {

--- a/demo/Saritasa.NetForge.Demo/Infrastructure/Admin/ShopAdminConfiguration.cs
+++ b/demo/Saritasa.NetForge.Demo/Infrastructure/Admin/ShopAdminConfiguration.cs
@@ -75,7 +75,7 @@ public class ShopAdminConfiguration : IEntityAdminConfiguration<Shop>
             })
             .IncludeNavigation<Product>(shop => shop.Products, navigationOptionsBuilder =>
             {
-                navigationOptionsBuilder.IncludeProperty(product => product.Id);
+                navigationOptionsBuilder.SetListViewPropertyNames([nameof(Product.Name)]);
             })
             .IncludeNavigation<Supplier>(shop => shop.Suppliers, navigationOptionsBuilder =>
             {

--- a/docs/NAVIGATIONS.md
+++ b/docs/NAVIGATIONS.md
@@ -185,3 +185,34 @@ It is not working for displaying navigation collection.
 
     public override int GetHashCode() => Street.GetHashCode() + City.GetHashCode();
 ```
+
+## List View Navigation Collection Display
+
+You can choose any property except navigations to represent navigation collection.
+
+We will use this data in examples:
+
+`Shop` entity has `Products` navigation collection:
+1. Id: 1, Name: Pasta, Price: 100
+2. Id: 2, Name: Sausage, Price: 500
+3. Id: 3, Name: Banana, Price 900
+
+### One Property
+
+Example when `Product.Name` is chosen:
+
+```text
+[ Pasta, Sausage, Banana ]
+```
+
+### Multiple Properties
+
+Example when `Product.Name` and `Product.Price` are chosen:
+
+```text
+[ { Pasta; 100 }, { Sausage; 500 }, { Banana; 900 } ]
+```
+
+### Default Behavior
+
+When no property is chosen then all primary keys will be used to display navigation collection.

--- a/src/Saritasa.NetForge/Controls/EntityPropertyColumns.razor
+++ b/src/Saritasa.NetForge/Controls/EntityPropertyColumns.razor
@@ -84,21 +84,16 @@
                         return;
                     }
 
+                    // When property is NavigationMetadataDto, then this property definitely is navigation collection.
+                    // See GetListViewProperties method in this class.
                     if (property is NavigationMetadataDto navigationMetadata)
                     {
-                        var navigationValue = GetNavigationValue(propertyValue, navigationMetadata);
+                        var navigationCollectionValue = GetNavigationCollectionValue(propertyValue, navigationMetadata);
 
-                        if (navigationMetadata.IsCollection)
-                        {
-                            <MudButton Variant="Variant.Text" Color="Color.Primary" Class="text-transform-none"
-                                       @onclick="() => OpenDialogAsync(propertyValue, navigationMetadata)">
-                                @navigationValue
-                            </MudButton>
-                        }
-                        else
-                        {
-                            @navigationValue
-                        }
+                        <MudButton Variant="Variant.Text" Color="Color.Primary" Class="text-transform-none"
+                                   @onclick="() => OpenDialogAsync(propertyValue, navigationMetadata)">
+                            @navigationCollectionValue
+                        </MudButton>
 
                         return;
                     }

--- a/src/Saritasa.NetForge/Controls/EntityPropertyColumns.razor.cs
+++ b/src/Saritasa.NetForge/Controls/EntityPropertyColumns.razor.cs
@@ -89,7 +89,7 @@ public partial class EntityPropertyColumns : ComponentBase
             : property.Name;
     }
 
-    private static object GetNavigationValue(object navigationInstance, NavigationMetadataDto navigationMetadata)
+    private static object GetNavigationCollectionValue(object navigationInstance, NavigationMetadataDto navigationMetadata)
     {
         var primaryKeys = navigationMetadata.TargetEntityProperties
             .Where(targetProperty => targetProperty.IsPrimaryKey)
@@ -100,16 +100,6 @@ public partial class EntityPropertyColumns : ComponentBase
             return navigationInstance;
         }
 
-        if (!navigationMetadata.IsCollection)
-        {
-            if (primaryKeys.Count == 1)
-            {
-                return navigationInstance.GetType().GetProperty(primaryKeys[0].Name)!.GetValue(navigationInstance)!;
-            }
-
-            return JoinPrimaryKeys(primaryKeys, navigationInstance);
-        }
-
         var navigationCollectionInstance = (navigationInstance as IEnumerable)!;
 
         if (navigationMetadata.ListViewPropertyNames.Count > 0)
@@ -118,14 +108,18 @@ public partial class EntityPropertyColumns : ComponentBase
 
             foreach (var item in navigationCollectionInstance)
             {
-                foreach (var propertyName in navigationMetadata.ListViewPropertyNames)
+                if (navigationMetadata.ListViewPropertyNames.Count == 1)
                 {
-                    var propertyValue = item.GetPropertyValue(propertyName);
+                    var propertyValue = item.GetPropertyValue(navigationMetadata.ListViewPropertyNames[0]);
                     propertyValues.Add(propertyValue);
+                }
+                else
+                {
+                    propertyValues.Add(JoinProperties(navigationMetadata.ListViewPropertyNames, item));
                 }
             }
 
-            return GetNavigationCollectionString(propertyValues);
+            return JoinNavigationValues(propertyValues);
         }
 
         var primaryKeyValues = new List<object?>();
@@ -138,25 +132,23 @@ public partial class EntityPropertyColumns : ComponentBase
             }
             else
             {
-                primaryKeyValues.Add($"{{ {JoinPrimaryKeys(primaryKeys, item)} }}");
+                var primaryKeyNames = primaryKeys.Select(primaryKey => primaryKey.Name);
+                primaryKeyValues.Add(JoinProperties(primaryKeyNames, item));
             }
         }
 
-        return GetNavigationCollectionString(primaryKeyValues);
+        return JoinNavigationValues(primaryKeyValues);
     }
 
-    private static string GetNavigationCollectionString(List<object?> valuesToDisplay)
+    private static string JoinProperties(IEnumerable<string> propertyNames, object navigation)
+    {
+        var propertyValues = propertyNames.Select(navigation.GetPropertyValue);
+        return $"{{ {string.Join("; ", propertyValues)} }}";
+    }
+
+    private static string JoinNavigationValues(List<object?> valuesToDisplay)
     {
         return $"[ {string.Join(", ", valuesToDisplay)} ]";
-    }
-
-    private static string JoinPrimaryKeys(IEnumerable<PropertyMetadataDto> primaryKeys, object navigation)
-    {
-        var primaryKeyValues = primaryKeys
-            .Select(primaryKey => primaryKey.Name)
-            .Select(primaryKeyName => navigation.GetType().GetProperty(primaryKeyName)!.GetValue(navigation));
-
-        return string.Join("; ", primaryKeyValues);
     }
 
     private string FormatValue(object value, PropertyMetadataDto propertyMetadata)

--- a/src/Saritasa.NetForge/Controls/EntityPropertyColumns.razor.cs
+++ b/src/Saritasa.NetForge/Controls/EntityPropertyColumns.razor.cs
@@ -110,9 +110,27 @@ public partial class EntityPropertyColumns : ComponentBase
             return JoinPrimaryKeys(primaryKeys, navigationInstance);
         }
 
+        var navigationCollectionInstance = (navigationInstance as IEnumerable)!;
+
+        if (navigationMetadata.ListViewPropertyNames.Count > 0)
+        {
+            List<object?> propertyValues = [];
+
+            foreach (var item in navigationCollectionInstance)
+            {
+                foreach (var propertyName in navigationMetadata.ListViewPropertyNames)
+                {
+                    var propertyValue = item.GetPropertyValue(propertyName);
+                    propertyValues.Add(propertyValue);
+                }
+            }
+
+            return GetNavigationCollectionString(propertyValues);
+        }
+
         var primaryKeyValues = new List<object?>();
 
-        foreach (var item in (navigationInstance as IEnumerable)!)
+        foreach (var item in navigationCollectionInstance)
         {
             if (primaryKeys.Count == 1)
             {
@@ -124,7 +142,12 @@ public partial class EntityPropertyColumns : ComponentBase
             }
         }
 
-        return $"[ {string.Join(", ", primaryKeyValues)} ]";
+        return GetNavigationCollectionString(primaryKeyValues);
+    }
+
+    private static string GetNavigationCollectionString(List<object?> valuesToDisplay)
+    {
+        return $"[ {string.Join(", ", valuesToDisplay)} ]";
     }
 
     private static string JoinPrimaryKeys(IEnumerable<PropertyMetadataDto> primaryKeys, object navigation)

--- a/src/Saritasa.NetForge/Domain/Entities/Metadata/NavigationMetadata.cs
+++ b/src/Saritasa.NetForge/Domain/Entities/Metadata/NavigationMetadata.cs
@@ -11,6 +11,11 @@ public class NavigationMetadata : PropertyMetadataBase
     public bool IsCollection { get; set; }
 
     /// <summary>
+    /// Property names that will be used on list view page to display navigation collection.
+    /// </summary>
+    public List<string> ListViewPropertyNames { get; set; } = [];
+
+    /// <summary>
     /// Target navigation entity's properties.
     /// </summary>
     public List<PropertyMetadata> TargetEntityProperties { get; set; } = [];

--- a/src/Saritasa.NetForge/Domain/Entities/Options/NavigationOptions.cs
+++ b/src/Saritasa.NetForge/Domain/Entities/Options/NavigationOptions.cs
@@ -13,6 +13,9 @@ public class NavigationOptions
     /// <inheritdoc cref="PropertyMetadataBase.FormOrder"/>
     public int? FormOrder { get; set; }
 
+    /// <inheritdoc cref="NavigationMetadata.ListViewPropertyNames"/>
+    public List<string> ListViewPropertyNames { get; set; } = [];
+
     /// <summary>
     /// Property options for the navigation properties.
     /// </summary>

--- a/src/Saritasa.NetForge/Domain/Extensions/EntityMetadataOptionsExtensions.cs
+++ b/src/Saritasa.NetForge/Domain/Extensions/EntityMetadataOptionsExtensions.cs
@@ -263,6 +263,8 @@ public static class EntityMetadataOptionsExtensions
             navigation.FormOrder = navigationOptions.FormOrder.Value;
         }
 
+        navigation.ListViewPropertyNames = navigationOptions.ListViewPropertyNames;
+
         foreach (var propertyOptions in navigationOptions.PropertyOptions)
         {
             var property = navigation.TargetEntityProperties

--- a/src/Saritasa.NetForge/Domain/NavigationOptionsBuilder.cs
+++ b/src/Saritasa.NetForge/Domain/NavigationOptionsBuilder.cs
@@ -86,12 +86,15 @@ public class NavigationOptionsBuilder<TEntity>
     }
 
     /// <summary>
-    /// Sets property names that will be used on list view page to display navigation collection.
+    /// Sets properties that will be used on list view page to display navigation collection.
     /// </summary>
-    /// <param name="propertyNames">Property names.</param>
-    public NavigationOptionsBuilder<TEntity> SetListViewPropertyNames(List<string> propertyNames)
+    /// <param name="propertyExpressions">Property expressions.</param>
+    public NavigationOptionsBuilder<TEntity> SetListViewProperties(
+        IEnumerable<Expression<Func<TEntity, object?>>> propertyExpressions)
     {
-        options.ListViewPropertyNames = propertyNames;
+        options.ListViewPropertyNames = propertyExpressions
+            .Select(expression => expression.GetMemberName())
+            .ToList();
         return this;
     }
 }

--- a/src/Saritasa.NetForge/Domain/NavigationOptionsBuilder.cs
+++ b/src/Saritasa.NetForge/Domain/NavigationOptionsBuilder.cs
@@ -84,4 +84,14 @@ public class NavigationOptionsBuilder<TEntity>
         options.NavigationsOptions.Add(navigationOptions);
         return this;
     }
+
+    /// <summary>
+    /// Sets property names that will be used on list view page to display navigation collection.
+    /// </summary>
+    /// <param name="propertyNames">Property names.</param>
+    public NavigationOptionsBuilder<TEntity> SetListViewPropertyNames(List<string> propertyNames)
+    {
+        options.ListViewPropertyNames = propertyNames;
+        return this;
+    }
 }

--- a/src/Saritasa.NetForge/Domain/UseCases/Metadata/GetEntityById/NavigationMetadataDto.cs
+++ b/src/Saritasa.NetForge/Domain/UseCases/Metadata/GetEntityById/NavigationMetadataDto.cs
@@ -10,6 +10,9 @@ public record NavigationMetadataDto : PropertyMetadataDto
     /// <inheritdoc cref="NavigationMetadata.IsCollection"/>
     public bool IsCollection { get; set; }
 
+    /// <inheritdoc cref="NavigationMetadata.ListViewPropertyNames"/>
+    public List<string> ListViewPropertyNames { get; init; } = [];
+
     /// <inheritdoc cref="NavigationMetadata.TargetEntityProperties"/>
     public List<PropertyMetadataDto> TargetEntityProperties { get; set; } = [];
 

--- a/src/Saritasa.NetForge/Domain/UseCases/Services/EntityService.cs
+++ b/src/Saritasa.NetForge/Domain/UseCases/Services/EntityService.cs
@@ -169,6 +169,7 @@ public class EntityService : IEntityService
             Lines = navigation.Lines,
             MaxLines = navigation.MaxLines,
             IsAutoGrow = navigation.IsAutoGrow,
+            ListViewPropertyNames = navigation.ListViewPropertyNames,
             NavigationMetadata = parentNavigation
         };
 

--- a/src/Saritasa.NetForge/wwwroot/index.css
+++ b/src/Saritasa.NetForge/wwwroot/index.css
@@ -1,3 +1,3 @@
-﻿.text-tranform-none > .mud-button-label {
+﻿.text-transform-none > .mud-button-label {
     text-transform: none;
 }


### PR DESCRIPTION
 `Suppliers` represent collection when one property is chosen to display. `Shop Products` represent collection when more than one property is chosen to display. We had this behavior before this PR, but only with primary keys, I tried to reuse this behavior here.

![image](https://github.com/user-attachments/assets/00fa8372-2916-4b99-92af-9f4de02b8f0e)
